### PR TITLE
feat(configuration): Abstract Configuration implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*~
+*.log
+glide.lock
+vendor
+.idea
+go.sum
+coverage.out
+.DS_Store

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2019
+# Intel
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+FROM nexus3.edgexfoundry.org:10004/edgex-golang-base:1.11.9-alpine
+
+LABEL license='SPDX-License-Identifier: Apache-2.0' \
+      copyright='Copyright (c) 2019: Intel'
+
+RUN apk add --update bash
+
+WORKDIR /go/src/github.com/edgexfoundry
+
+COPY go.mod .
+
+RUN go mod download

--- a/Dockerfile.build-arm64
+++ b/Dockerfile.build-arm64
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2019
+# Intel
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+FROM nexus3.edgexfoundry.org:10004/edgex-golang-base:1.11.9-alpine-arm64
+
+LABEL license='SPDX-License-Identifier: Apache-2.0' \
+      copyright='Copyright (c) 2019: Intel'
+
+RUN apk add --update bash
+
+WORKDIR /go/src/github.com/edgexfoundry
+
+COPY go.mod .
+
+RUN go mod download

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,127 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+loadGlobalLibrary()
+
+pipeline {
+    agent {
+        label 'centos7-docker-4c-2g'
+    }
+
+    options {
+        timestamps()
+    }
+
+    stages {
+        stage('LF Prep') {
+            steps {
+                edgeXSetupEnvironment()
+                edgeXDockerLogin(settingsFile: env.MVN_SETTINGS)
+            }
+        }
+
+        stage('Multi-Arch Build') {
+            // fan out
+            parallel {
+                stage('Test amd64') {
+                    agent {
+                        dockerfile {
+                            filename 'Dockerfile.build'
+                            label 'centos7-docker-4c-2g'
+                            args '-u 0:0' // needed for go mod cache
+                        }
+                    }
+                    steps {
+                        sh 'make test'
+                        edgeXCodecov('go-mod-configuration-codecov-token')
+                    }
+                }
+                stage('Test arm64') {
+                    agent {
+                        dockerfile {
+                            filename 'Dockerfile.build-arm64'
+                            label 'ubuntu18.04-docker-arm64-4c-2g'
+                            args '-u 0:0' // needed for go mod cache
+                        }
+                    }
+                    steps {
+                        sh 'make test'
+                        edgeXCodecov('go-mod-configuration-codecov-token')
+                    }
+                }
+            }
+        }
+
+        stage('Semver Init') {
+            when { expression { edgex.isReleaseStream() } }
+            steps {
+                edgeXSemver 'init'
+                script {
+                    def semverVersion = edgeXSemver()
+                    env.setProperty('VERSION', semverVersion)
+                }
+            }
+        }
+
+        stage('Semver Tag') {
+            when { expression { edgex.isReleaseStream() } }
+            steps {
+                edgeXSemver('tag')
+            }
+        }
+
+        stage('Sigul Sign Tag') {
+            when { expression { edgex.isReleaseStream() } }
+            steps {
+                edgeXInfraLFToolsSign(command: 'git-tag', version: 'v${VERSION}')
+            }
+        }
+
+        stage('Semver Bump Patch Version') {
+            when { expression { edgex.isReleaseStream() } }
+            steps {
+                edgeXSemver('bump patch')
+                edgeXSemver('push')
+            }
+        }
+    }
+
+    post {
+        failure {
+            script {
+                currentBuild.result = "FAILED"
+            }
+        }
+        always {
+            edgeXInfraPublish()
+        }
+    }
+}
+
+def loadGlobalLibrary(branch = '*/master') {
+    library(identifier: 'edgex-global-pipelines@master', 
+        retriever: legacySCM([
+            $class: 'GitSCM',
+            userRemoteConfigs: [[url: 'https://github.com/edgexfoundry/edgex-global-pipelines.git']],
+            branches: [[name: branch]],
+            doGenerateSubmoduleConfigurations: false,
+            extensions: [[
+                $class: 'SubmoduleOption',
+                recursiveSubmodules: true,
+            ]]]
+        )
+    ) _
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2017 Dell, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: test
+
+GO=CGO_ENABLED=0 GO111MODULE=on go
+
+test:
+	$(GO) test ./... -coverprofile=coverage.out ./...
+	$(GO) vet ./...
+	gofmt -l .
+	[ "`gofmt -l .`" = "" ]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,121 @@
 # go-mod-configuration
+Configuration client library for use by Go implementation of EdgeX micro services.  This project contains the abstract Configuration API and an implementation for Consul. The API initializes a connection to the Configuration service and push/pull configuration values to/from the Configuration service.
+
+### What is this repository for? ###
+* Initialize connection to a Configuration service
+* Push a service's configuration in to the Configuration
+* Pull service's configuration from the Configuration service into its configuration struct
+* Listen for configuration updates
+
+### Installation ###
+* Make sure you have Go Modules enabled, i.e. have an initialized  go.mod file 
+* If your code is in your GOPATH then make sure ```GO111MODULE=on``` is set
+* Run ```go get github.com/edgexfoundry/go-mod-configuration```
+    * This will add the go-mod-configuration to the go.mod file and download it into the module cache
+    
+### How to Use ###
+This library is used by Go programs for interacting with the Configuration service (i.e. Consul) and requires that a Configuration service be running somewhere that the Configuration Client can connect.  The types.ServiceConfig struct is used to specify the service implementation details :
+
+```go
+type ServiceConfig struct {
+	Protocol string
+	Host string
+	Port int
+	Type string
+	BasePath string
+}
+```
+
+The following code snippets demonstrate how a service uses this Configuration module to store and load configuration, listen to for configuration updates.
+
+This code snippet shows how to connect to the Configuration service, store and load the service's configuration from the Configuration service.  
+```
+func initializeConfiguration(useConfigService bool, useProfile string) (*ConfigurationStruct, error) {
+	configuration := &ConfigurationStruct{}
+	err := config.LoadFromFile(useProfile, configuration)
+	if err != nil {
+		return nil, err
+	}
+
+    if useConfigService {
+        serviceConfig := types.Config{
+            Host:            conf.Configuration.Host,
+            Port:            conf.Configuration.Port,
+            Type:            conf.Configuration.Type,
+            BasePath:        internal.ConfigStem + internal.MyServiceKey,
+        }
+
+        ConfigClient, err = configuration.NewConfigurationClient(serviceConfig)
+    	if err != nil {
+    		return fmt.Errorf("connection to Configuration service could not be made: %v", err.Error())
+    	}
+
+
+		hasConfig, err := ConfigClient.HasConfiguration()
+		if hasConfig {
+            // Get the service's configuration from the Configuration service
+            rawConfig, err := ConfigClient.GetConfiguration(configuration)
+            if err != nil {
+                return fmt.Errorf("could not get configuration from Configuration: %v", err.Error())
+            }
+
+            actual, ok := rawConfig.(*ConfigurationStruct)
+            if !ok {
+                return fmt.Errorf("configuration from Configuration failed type check")
+            }
+
+            *configuration = actual
+        } else {
+            err = ConfigClient.PutConfiguration(configuration, true)
+			if err != nil {
+				return fmt.Errorf("could not push configuration into Configuration service: %v", err)
+			}
+        }
+        
+        // Run as go func so doesn't block
+        go listenForConfigChanges()
+    }
+```
+
+This code snippet shows how to listen for configuration changes from the Configuration service after connecting  above.
+
+```
+func listenForConfigChanges() {
+	if ConfigClient == nil {
+		LoggingClient.Error("listenForConfigChanges() configuration client not set")
+		return
+	}
+
+	ConfigClient.WatchForChanges(updateChannel, errChannel, &WritableInfo{}, internal.WritableKey)
+
+	signalChan := make(chan os.Signal)
+	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
+
+	for {
+		select {
+		case <- signalChan:
+			// Quietly and gracefully stop when SIGINT/SIGTERM received
+			return
+
+		case ex := <-errChannel:
+			LoggingClient.Error(ex.Error())
+
+		case raw, ok := <-updateChannel:
+			if !ok {
+				return
+			}
+
+			actual, ok := raw.(*WritableInfo)
+			if !ok {
+				LoggingClient.Error("listenForConfigChanges() type check failed")
+				return
+			}
+
+			Configuration.Writable = *actual
+
+			LoggingClient.Info("Writeable configuration has been updated")
+			LoggingClient.SetLogLevel(Configuration.Writable.LogLevel)
+		}
+	}
+}
+```

--- a/configuration/factory.go
+++ b/configuration/factory.go
@@ -1,0 +1,40 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package configuration
+
+import (
+	"fmt"
+
+	"github.com/edgexfoundry/go-mod-configuration/internal/pkg/consul"
+	"github.com/edgexfoundry/go-mod-configuration/pkg/types"
+)
+
+func NewConfigurationClient(config types.ServiceConfig) (Client, error) {
+
+	if config.Host == "" || config.Port == 0 {
+		return nil, fmt.Errorf("unable to create Configuation Client: Configuation service host and/or port or serviceKey not set")
+	}
+
+	switch config.Type {
+	case "consul":
+		var err error
+		client, err := consul.NewConsulClient(config)
+		return client, err
+	default:
+		return nil, fmt.Errorf("unknown configuration client type '%s' requested", config.Type)
+	}
+}

--- a/configuration/factory_test.go
+++ b/configuration/factory_test.go
@@ -1,0 +1,53 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package configuration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/edgexfoundry/go-mod-configuration/pkg/types"
+)
+
+var config = types.ServiceConfig{
+	Host:     "localhost",
+	Port:     8500,
+	BasePath: "config",
+}
+
+func TestNewClientConsul(t *testing.T) {
+
+	config.Type = "consul"
+
+	client, err := NewConfigurationClient(config)
+	if assert.Nil(t, err, "New Configuration client failed: ", err) == false {
+		t.Fatal()
+	}
+
+	assert.False(t, client.IsAlive(), "Consul service not expected be running")
+}
+
+func TestNewClientBogusType(t *testing.T) {
+
+	config.Type = "bogus"
+
+	_, err := NewConfigurationClient(config)
+	if assert.NotNil(t, err, "Expected configuration type type error") == false {
+		t.Fatal()
+	}
+}

--- a/configuration/interface.go
+++ b/configuration/interface.go
@@ -1,0 +1,54 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package configuration
+
+import (
+	"github.com/pelletier/go-toml"
+)
+
+type Client interface {
+	// Checks to see if the Configuration service contains the service's configuration.
+	HasConfiguration() (bool, error)
+
+	// Puts a full toml configuration into the Configuration service
+	PutConfigurationToml(configuration *toml.Tree, overwrite bool) error
+
+	// Puts a full configuration struct into the Configuration service
+	PutConfiguration(configStruct interface{}, overwrite bool) error
+
+	// Gets the full configuration from Consul into the target configuration struct.
+	// Passed in struct is only a reference for Configuration service. Empty struct is fine
+	// Returns the configuration in the target struct as interface{}, which caller must cast
+	GetConfiguration(configStruct interface{}) (interface{}, error)
+
+	// Sets up a Consul watch for the target key and send back updates on the update channel.
+	// Passed in struct is only a reference for Configuration service, empty struct is ok
+	// Sends the configuration in the target struct as interface{} on updateChannel, which caller must cast
+	WatchForChanges(updateChannel chan<- interface{}, errorChannel chan<- error, configuration interface{}, waitKey string)
+
+	// Simply checks if Configuration service is up and running at the configured URL
+	IsAlive() bool
+
+	// Checks if a configuration value exists in the Configuration service
+	ConfigurationValueExists(name string) (bool, error)
+
+	// Gets a specific configuration value from the Configuration service
+	GetConfigurationValue(name string) ([]byte, error)
+
+	// Puts a specific configuration value into the Configuration service
+	PutConfigurationValue(name string, value []byte) error
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,12 @@
+module github.com/edgexfoundry/go-mod-configuration
+
+require (
+	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
+	github.com/hashicorp/consul/api v1.1.0
+	github.com/mitchellh/consulstructure v0.0.0-20190329231841-56fdc4d2da54
+	github.com/mitchellh/copystructure v1.0.0 // indirect
+	github.com/pelletier/go-toml v1.2.0
+	github.com/stretchr/testify v1.3.0
+)
+
+go 1.12

--- a/internal/pkg/consul/client.go
+++ b/internal/pkg/consul/client.go
@@ -1,0 +1,296 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package consul
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	consulapi "github.com/hashicorp/consul/api"
+	"github.com/mitchellh/consulstructure"
+	"github.com/pelletier/go-toml"
+
+	"github.com/edgexfoundry/go-mod-configuration/pkg/types"
+)
+
+const consulStatusPath = "/v1/status/leader"
+
+type consulClient struct {
+	consulUrl      string
+	consulClient   *consulapi.Client
+	consulConfig   *consulapi.Config
+	configBasePath string
+}
+
+// Create new Consul Client. Service details are optional, not needed just for configuration, but required if registering
+func NewConsulClient(config types.ServiceConfig) (*consulClient, error) {
+
+	client := consulClient{
+		consulUrl:      config.GetUrl(),
+		configBasePath: config.BasePath,
+	}
+
+	if len(client.configBasePath) > 0 && client.configBasePath[len(client.configBasePath)-1:] != "/" {
+		client.configBasePath = client.configBasePath + "/"
+	}
+
+	var err error
+
+	client.consulConfig = consulapi.DefaultConfig()
+	client.consulConfig.Address = client.consulUrl
+	client.consulClient, err = consulapi.NewClient(client.consulConfig)
+	if err != nil {
+		return nil, fmt.Errorf("unable for create new Consul Client for %s: %v", client.consulUrl, err)
+	}
+
+	return &client, nil
+}
+
+// Simply checks if Consul is up and running at the configured URL
+func (client *consulClient) IsAlive() bool {
+	netClient := http.Client{Timeout: time.Second * 10}
+
+	resp, err := netClient.Get(client.consulUrl + consulStatusPath)
+	if err != nil {
+		return false
+	}
+
+	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+		return true
+	}
+
+	return false
+}
+
+// Checks to see if Consul contains the service's configuration.
+func (client *consulClient) HasConfiguration() (bool, error) {
+	if stemKeys, _, err := client.consulClient.KV().Keys(client.configBasePath, "", nil); err != nil {
+		return false, fmt.Errorf("checking configuration existence from Consul failed: %v", err)
+	} else if len(stemKeys) == 0 {
+		return false, nil
+	} else {
+		return true, nil
+	}
+}
+
+// Puts a full toml configuration into Consul
+func (client *consulClient) PutConfigurationToml(configuration *toml.Tree, overwrite bool) error {
+
+	configurationMap := configuration.ToMap()
+	keyValues := convertInterfaceToConsulPairs("", configurationMap)
+
+	// Put config properties into Consul.
+	for _, keyValue := range keyValues {
+		exists, _ := client.ConfigurationValueExists(keyValue.Key)
+		if !exists || overwrite {
+			if err := client.PutConfigurationValue(keyValue.Key, []byte(keyValue.Value)); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// Puts a full configuration struct into the Configuration provider
+func (client *consulClient) PutConfiguration(configuration interface{}, overwrite bool) error {
+	bytes, err := toml.Marshal(configuration)
+	if err != nil {
+		return err
+	}
+
+	tree, err := toml.LoadBytes(bytes)
+	if err != nil {
+		return err
+	}
+
+	err = client.PutConfigurationToml(tree, overwrite)
+	if err != nil {
+		return err
+	}
+
+	return nil
+
+}
+
+// Gets the full configuration from Consul into the target configuration struct.
+// Passed in struct is only a reference for decoder, empty struct is ok
+// Returns the configuration in the target struct as interface{}, which caller must cast
+func (client *consulClient) GetConfiguration(configStruct interface{}) (interface{}, error) {
+	var err error
+	var configuration interface{}
+
+	exists, err := client.HasConfiguration()
+	if err != nil {
+		return nil, err
+	}
+
+	if !exists {
+		return nil, fmt.Errorf("the Configuration service (Consul) doesn't contain configuration for %s", client.configBasePath)
+	}
+
+	// Update configuration data from Consul using decoder
+	updateChannel := make(chan interface{})
+	errorChannel := make(chan error)
+
+	decoder := client.newConsulDecoder()
+	decoder.Consul = client.consulConfig
+	decoder.Target = configStruct
+	decoder.Prefix = client.configBasePath
+	decoder.ErrCh = errorChannel
+	decoder.UpdateCh = updateChannel
+
+	defer func() {
+		decoder.Close()
+		close(updateChannel)
+		close(errorChannel)
+	}()
+
+	go decoder.Run()
+
+	select {
+	case <-time.After(2 * time.Second):
+		err = errors.New("timeout loading config from client")
+	case ex := <-errorChannel:
+		err = errors.New(ex.Error())
+	case raw := <-updateChannel:
+		configuration = raw
+	}
+
+	return configuration, err
+}
+
+// Sets up a Consul watch for the target key and send back updates on the update channel.
+// Passed in struct is only a reference for decoder, empty struct is ok
+// Sends the configuration in the target struct as interface{} on updateChannel, which caller must cast
+func (client *consulClient) WatchForChanges(updateChannel chan<- interface{}, errorChannel chan<- error, configuration interface{}, watchKey string) {
+	// some watch keys may have start with "/", need to remove it since the base path already has it.
+	if strings.Index(watchKey, "/") == 0 {
+		watchKey = watchKey[1:]
+	}
+
+	decoder := client.newConsulDecoder()
+	decoder.Consul = client.consulConfig
+	decoder.Target = configuration
+	decoder.Prefix = client.configBasePath + watchKey
+	decoder.ErrCh = errorChannel
+	decoder.UpdateCh = updateChannel
+
+	go decoder.Run()
+}
+
+// Checks if a configuration value exists in Consul
+func (client *consulClient) ConfigurationValueExists(name string) (bool, error) {
+	keyPair, _, err := client.consulClient.KV().Get(client.fullPath(name), nil)
+	if err != nil {
+		return false, fmt.Errorf("unable to check existence of %s in Consul: %v", client.fullPath(name), err)
+	}
+	return keyPair != nil, nil
+}
+
+// Gets a specific configuration value from Consul
+func (client *consulClient) GetConfigurationValue(name string) ([]byte, error) {
+	keyPair, _, err := client.consulClient.KV().Get(client.fullPath(name), nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get value for %s from Consul: %v", client.fullPath(name), err)
+	}
+
+	if keyPair == nil {
+		return nil, nil
+	}
+
+	return keyPair.Value, nil
+}
+
+// Puts a specific configuration value into Consul
+func (client *consulClient) PutConfigurationValue(name string, value []byte) error {
+	keyPair := &consulapi.KVPair{
+		Key:   client.fullPath(name),
+		Value: value,
+	}
+
+	_, err := client.consulClient.KV().Put(keyPair, nil)
+	if err != nil {
+		return fmt.Errorf("unable to put value for %s into Consul: %v", client.fullPath(name), err)
+	}
+	return nil
+}
+
+func (client *consulClient) fullPath(name string) string {
+	return client.configBasePath + name
+}
+
+type pair struct {
+	Key   string
+	Value string
+}
+
+func convertInterfaceToConsulPairs(path string, interfaceMap interface{}) []*pair {
+	pairs := make([]*pair, 0)
+
+	pathPre := ""
+	if path != "" {
+		pathPre = path + "/"
+	}
+
+	switch interfaceMap.(type) {
+	case []interface{}:
+		for index, item := range interfaceMap.([]interface{}) {
+			nextPairs := convertInterfaceToConsulPairs(pathPre+strconv.Itoa(index), item)
+			pairs = append(pairs, nextPairs...)
+		}
+
+	case map[string]interface{}:
+		for index, item := range interfaceMap.(map[string]interface{}) {
+			nextPairs := convertInterfaceToConsulPairs(pathPre+index, item)
+			pairs = append(pairs, nextPairs...)
+		}
+
+	case int:
+		pairs = append(pairs, &pair{Key: path, Value: strconv.Itoa(interfaceMap.(int))})
+
+	case int64:
+		var value = int(interfaceMap.(int64))
+		pairs = append(pairs, &pair{Key: path, Value: strconv.Itoa(value)})
+
+	case float64:
+		pairs = append(pairs, &pair{Key: path, Value: strconv.FormatFloat(interfaceMap.(float64), 'f', -1, 64)})
+
+	case bool:
+		pairs = append(pairs, &pair{Key: path, Value: strconv.FormatBool(interfaceMap.(bool))})
+
+	case nil:
+		pairs = append(pairs, &pair{Key: path, Value: ""})
+
+	default:
+		pairs = append(pairs, &pair{Key: path, Value: interfaceMap.(string)})
+	}
+
+	return pairs
+}
+
+func (client *consulClient) newConsulDecoder() *consulstructure.Decoder {
+	return &consulstructure.Decoder{
+		Consul: &consulapi.Config{
+			Address: client.consulUrl,
+		},
+	}
+}

--- a/internal/pkg/consul/client_test.go
+++ b/internal/pkg/consul/client_test.go
@@ -1,0 +1,581 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package consul
+
+import (
+	"log"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/pelletier/go-toml"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/edgexfoundry/go-mod-configuration/pkg/types"
+)
+
+const (
+	serviceName    = "consulUnitTest"
+	consulBasePath = "edgex/core/1.0/"
+)
+
+// change values to localhost and 8500 if you need to run tests against real Consul service running locally
+var (
+	testHost = ""
+	port     = 0
+)
+
+type LoggingInfo struct {
+	EnableRemote bool
+	File         string
+}
+
+type MyConfig struct {
+	Logging  LoggingInfo
+	Port     int
+	Host     string
+	LogLevel string
+}
+
+var mockConsul *MockConsul
+
+func TestMain(m *testing.M) {
+
+	var testMockServer *httptest.Server
+	if testHost == "" || port != 8500 {
+		mockConsul = NewMockConsul()
+		testMockServer = mockConsul.Start()
+
+		URL, _ := url.Parse(testMockServer.URL)
+		testHost = URL.Hostname()
+		port, _ = strconv.Atoi(URL.Port())
+	}
+
+	exitCode := m.Run()
+	if testMockServer != nil {
+		defer testMockServer.Close()
+	}
+	os.Exit(exitCode)
+}
+
+func TestIsAlive(t *testing.T) {
+	client := makeConsulClient(t, getUniqueServiceName())
+	if !client.IsAlive() {
+		t.Fatal("Consul not running")
+	}
+}
+
+func TestHasConfigurationFalse(t *testing.T) {
+	client := makeConsulClient(t, getUniqueServiceName())
+
+	// Make sure the configuration doesn't already exists
+	reset(t, client)
+
+	// Don't push anything in yet so configuration will not exists
+
+	actual, err := client.HasConfiguration()
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+
+	assert.False(t, actual)
+}
+
+func TestHasConfigurationTrue(t *testing.T) {
+	client := makeConsulClient(t, getUniqueServiceName())
+
+	// Make sure the configuration doesn't already exists
+	reset(t, client)
+
+	// Now push a value so the configuration will exist
+	_ = client.PutConfigurationValue("Dummy", []byte("Value"))
+
+	actual, err := client.HasConfiguration()
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+
+	assert.True(t, actual)
+}
+
+func TestHasConfigurationPartialServiceKey(t *testing.T) {
+	client := makeConsulClient(t, getUniqueServiceName())
+
+	// Make sure the configuration doesn't already exists
+	reset(t, client)
+
+	base := client.configBasePath
+	if strings.LastIndex(base, "/") == len(base)-1 {
+		base = base[:len(base)-1]
+	}
+	// Add a key with similar base path
+	keyPair := api.KVPair{
+		Key:   base + "-test/some-key",
+		Value: []byte("Nothing"),
+	}
+	_, err := client.consulClient.KV().Put(&keyPair, nil)
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+
+	actual, err := client.HasConfiguration()
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+
+	assert.False(t, actual)
+}
+
+func TestHasConfigurationError(t *testing.T) {
+	goodPort := port
+	port = 1234 // change the Consul port to bad port
+	defer func() {
+		port = goodPort
+	}()
+
+	client := makeConsulClient(t, getUniqueServiceName())
+
+	_, err := client.HasConfiguration()
+	assert.Error(t, err, "expected error checking configuration existence")
+
+	assert.Contains(t, err.Error(), "checking configuration existence")
+}
+
+func TestConfigurationValueExists(t *testing.T) {
+	key := "Foo"
+	value := []byte("bar")
+	uniqueServiceName := getUniqueServiceName()
+	fullKey := consulBasePath + uniqueServiceName + "/" + key
+
+	client := makeConsulClient(t, uniqueServiceName)
+	expected := false
+
+	// Make sure the configuration doesn't already exists
+	reset(t, client)
+
+	actual, err := client.ConfigurationValueExists(key)
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+	if !assert.False(t, actual) {
+		t.Fatal()
+	}
+
+	keyPair := api.KVPair{
+		Key:   fullKey,
+		Value: value,
+	}
+
+	_, err = client.consulClient.KV().Put(&keyPair, nil)
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+
+	expected = true
+	actual, err = client.ConfigurationValueExists(key)
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+	if !assert.Equal(t, expected, actual) {
+		t.Fatal()
+	}
+}
+
+func TestGetConfigurationValue(t *testing.T) {
+	key := "Foo"
+	expected := []byte("bar")
+	uniqueServiceName := getUniqueServiceName()
+	fullKey := consulBasePath + uniqueServiceName + "/" + key
+	client := makeConsulClient(t, uniqueServiceName)
+
+	// Make sure the target key/value exists
+	keyPair := api.KVPair{
+		Key:   fullKey,
+		Value: expected,
+	}
+
+	_, err := client.consulClient.KV().Put(&keyPair, nil)
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+
+	actual, err := client.GetConfigurationValue(key)
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+	if !assert.Equal(t, expected, actual) {
+		t.Fatal()
+	}
+}
+
+func TestPutConfigurationValue(t *testing.T) {
+	key := "Foo"
+	expected := []byte("bar")
+	uniqueServiceName := getUniqueServiceName()
+	expectedFullKey := consulBasePath + uniqueServiceName + "/" + key
+
+	client := makeConsulClient(t, uniqueServiceName)
+
+	// Make sure the configuration doesn't already exists
+	reset(t, client)
+
+	_, _ = client.consulClient.KV().Delete(expectedFullKey, nil)
+
+	err := client.PutConfigurationValue(key, expected)
+	assert.NoError(t, err)
+
+	keyValue, _, err := client.consulClient.KV().Get(expectedFullKey, nil)
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+	if !assert.NotNil(t, keyValue, "%s value not found", expectedFullKey) {
+		t.Fatal()
+	}
+
+	actual := keyValue.Value
+
+	assert.Equal(t, expected, actual)
+
+}
+
+func TestGetConfiguration(t *testing.T) {
+	expected := MyConfig{
+		Logging: LoggingInfo{
+			EnableRemote: true,
+			File:         "NONE",
+		},
+		Port:     8000,
+		Host:     "localhost",
+		LogLevel: "debug",
+	}
+
+	client := makeConsulClient(t, getUniqueServiceName())
+
+	_ = client.PutConfigurationValue("Logging/EnableRemote", []byte(strconv.FormatBool(expected.Logging.EnableRemote)))
+	_ = client.PutConfigurationValue("Logging/File", []byte(expected.Logging.File))
+	_ = client.PutConfigurationValue("Port", []byte(strconv.Itoa(expected.Port)))
+	_ = client.PutConfigurationValue("Host", []byte(expected.Host))
+	_ = client.PutConfigurationValue("LogLevel", []byte(expected.LogLevel))
+
+	result, err := client.GetConfiguration(&MyConfig{})
+
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+
+	configuration := result.(*MyConfig)
+
+	if !assert.NotNil(t, configuration) {
+		t.Fatal()
+	}
+
+	assert.Equal(t, expected.Logging.EnableRemote, configuration.Logging.EnableRemote, "Logging.EnableRemote not as expected")
+	assert.Equal(t, expected.Logging.File, configuration.Logging.File, "Logging.File not as expected")
+	assert.Equal(t, expected.Port, configuration.Port, "Port not as expected")
+	assert.Equal(t, expected.Host, configuration.Host, "Host not as expected")
+	assert.Equal(t, expected.LogLevel, configuration.LogLevel, "LogLevel not as expected")
+}
+
+func TestPutConfiguration(t *testing.T) {
+	expected := MyConfig{
+		Logging: LoggingInfo{
+			EnableRemote: true,
+			File:         "NONE",
+		},
+		Port:     8000,
+		Host:     "localhost",
+		LogLevel: "debug",
+	}
+
+	client := makeConsulClient(t, getUniqueServiceName())
+
+	// Make sure the tree of values doesn't exist.
+	_, _ = client.consulClient.KV().DeleteTree(consulBasePath, nil)
+
+	defer func() {
+		// Clean up
+		_, _ = client.consulClient.KV().DeleteTree(consulBasePath, nil)
+	}()
+
+	err := client.PutConfiguration(expected, true)
+	if !assert.NoErrorf(t, err, "unable to put configuration: %v", err) {
+		t.Fatal()
+	}
+
+	actual, err := client.HasConfiguration()
+	if !assert.True(t, actual, "Failed to put configuration") {
+		t.Fail()
+	}
+
+	assert.True(t, configValueSet("Logging/EnableRemote", client))
+	assert.True(t, configValueSet("Logging/File", client))
+	assert.True(t, configValueSet("Port", client))
+	assert.True(t, configValueSet("Host", client))
+	assert.True(t, configValueSet("LogLevel", client))
+}
+
+func configValueSet(key string, client *consulClient) bool {
+	exists, _ := client.ConfigurationValueExists(key)
+	return exists
+}
+
+func TestPutConfigurationTomlNoPreviousValues(t *testing.T) {
+	client := makeConsulClient(t, getUniqueServiceName())
+
+	// Make sure the tree of values doesn't exist.
+	_, _ = client.consulClient.KV().DeleteTree(consulBasePath, nil)
+
+	defer func() {
+		// Clean up
+		_, _ = client.consulClient.KV().DeleteTree(consulBasePath, nil)
+	}()
+
+	configMap := createKeyValueMap()
+	configuration, err := toml.TreeFromMap(configMap)
+	if err != nil {
+		log.Fatalf("unable to create TOML Tree from map: %v", err)
+	}
+	err = client.PutConfigurationToml(configuration, false)
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+
+	keyValues := convertInterfaceToConsulPairs("", configMap)
+	for _, keyValue := range keyValues {
+		expected := keyValue.Value
+		value, err := client.GetConfigurationValue(keyValue.Key)
+		if !assert.NoError(t, err) {
+			t.Fatal()
+		}
+		actual := string(value)
+		if !assert.Equal(t, expected, actual, "Values for %s are not equal", keyValue.Key) {
+			t.Fatal()
+		}
+	}
+}
+
+func TestPutConfigurationTomlWithoutOverWrite(t *testing.T) {
+	client := makeConsulClient(t, getUniqueServiceName())
+
+	// Make sure the tree of values doesn't exist.
+	_, _ = client.consulClient.KV().DeleteTree(consulBasePath, nil)
+
+	defer func() {
+		// Clean up
+		_, _ = client.consulClient.KV().DeleteTree(consulBasePath, nil)
+	}()
+
+	configMap := createKeyValueMap()
+
+	configuration, _ := toml.TreeFromMap(configMap)
+	err := client.PutConfigurationToml(configuration, false)
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+
+	//Update map with new value and try to overwrite it
+	configMap["int"] = 2
+	configMap["int64"] = 164
+	configMap["float64"] = 2.4
+	configMap["string"] = "bye"
+	configMap["bool"] = false
+
+	// Try to put new values with overwrite = false
+	configuration, _ = toml.TreeFromMap(configMap)
+	err = client.PutConfigurationToml(configuration, false)
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+
+	keyValues := convertInterfaceToConsulPairs("", configMap)
+	for _, keyValue := range keyValues {
+		expected := keyValue.Value
+		value, err := client.GetConfigurationValue(keyValue.Key)
+		if !assert.NoError(t, err) {
+			t.Fatal()
+		}
+		actual := string(value)
+		if !assert.NotEqual(t, expected, actual, "Values for %s are equal, expected not equal", keyValue.Key) {
+			t.Fatal()
+		}
+	}
+}
+
+func TestPutConfigurationTomlOverWrite(t *testing.T) {
+	client := makeConsulClient(t, getUniqueServiceName())
+
+	// Make sure the tree of values doesn't exist.
+	_, _ = client.consulClient.KV().DeleteTree(consulBasePath, nil)
+	// Clean up after unit test
+	defer func() {
+		_, _ = client.consulClient.KV().DeleteTree(consulBasePath, nil)
+	}()
+
+	configMap := createKeyValueMap()
+
+	configuration, _ := toml.TreeFromMap(configMap)
+	err := client.PutConfigurationToml(configuration, false)
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+
+	//Update map with new value and try to overwrite it
+	configMap["int"] = 2
+	configMap["float64"] = 2.4
+	configMap["string"] = "bye"
+	configMap["bool"] = false
+
+	// Try to put new values with overwrite = True
+	configuration, _ = toml.TreeFromMap(configMap)
+	err = client.PutConfigurationToml(configuration, true)
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+
+	keyValues := convertInterfaceToConsulPairs("", configMap)
+	for _, keyValue := range keyValues {
+		expected := keyValue.Value
+		value, err := client.GetConfigurationValue(keyValue.Key)
+		if !assert.NoError(t, err) {
+			t.Fatal()
+		}
+		actual := string(value)
+		if !assert.Equal(t, expected, actual, "Values for %s are not equal", keyValue.Key) {
+			t.Fatal()
+		}
+	}
+}
+
+func TestWatchForChanges(t *testing.T) {
+	expectedConfig := MyConfig{
+		Logging: LoggingInfo{
+			EnableRemote: true,
+			File:         "NONE",
+		},
+		Port:     8000,
+		Host:     "localhost",
+		LogLevel: "debug",
+	}
+
+	expectedChange := "random"
+
+	client := makeConsulClient(t, getUniqueServiceName())
+
+	// Make sure the tree of values doesn't exist.
+	_, _ = client.consulClient.KV().DeleteTree(consulBasePath, nil)
+	// Clean up after unit test
+	defer func() {
+		_, _ = client.consulClient.KV().DeleteTree(consulBasePath, nil)
+	}()
+
+	_ = client.PutConfigurationValue("Logging/EnableRemote", []byte(strconv.FormatBool(expectedConfig.Logging.EnableRemote)))
+	_ = client.PutConfigurationValue("Logging/File", []byte(expectedConfig.Logging.File))
+	_ = client.PutConfigurationValue("Port", []byte(strconv.Itoa(expectedConfig.Port)))
+	_ = client.PutConfigurationValue("Host", []byte(expectedConfig.Host))
+	_ = client.PutConfigurationValue("LogLevel", []byte(expectedConfig.LogLevel))
+
+	loggingUpdateChannel := make(chan interface{})
+	errorChannel := make(chan error)
+
+	client.WatchForChanges(loggingUpdateChannel, errorChannel, &LoggingInfo{}, "Logging")
+
+	loggingPass := 1
+
+	for {
+		select {
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timeout waiting on Logging configuration loggingChanges")
+
+		case loggingChanges := <-loggingUpdateChannel:
+			assert.NotNil(t, loggingChanges)
+			logInfo := loggingChanges.(*LoggingInfo)
+
+			// first pass is for Consul Decoder always sending data once watch has been setup. It hasn't actually changed
+			if loggingPass == 1 {
+				if !assert.Equal(t, logInfo.File, expectedConfig.Logging.File) {
+					t.Fatal()
+				}
+
+				// Make a change to logging
+				_ = client.PutConfigurationValue("Logging/File", []byte(expectedChange))
+
+				loggingPass--
+				continue
+			}
+
+			// Now the data should have changed
+			assert.Equal(t, logInfo.File, expectedChange)
+			return
+
+		case waitError := <-errorChannel:
+			t.Fatalf("received WatchForChanges error for Logging: %v", waitError)
+		}
+	}
+}
+
+func makeConsulClient(t *testing.T, serviceName string) *consulClient {
+	config := types.ServiceConfig{
+		Host:     testHost,
+		Port:     port,
+		BasePath: "edgex/core/1.0/" + serviceName,
+	}
+
+	client, err := NewConsulClient(config)
+	if assert.NoError(t, err) == false {
+		t.Fatal()
+	}
+
+	return client
+}
+
+func createKeyValueMap() map[string]interface{} {
+	configMap := make(map[string]interface{})
+
+	configMap["int"] = 1
+	configMap["int64"] = int64(64)
+	configMap["float64"] = float64(1.4)
+	configMap["string"] = "hello"
+	configMap["bool"] = true
+
+	return configMap
+}
+
+func reset(t *testing.T, client *consulClient) {
+	// Make sure the configuration doesn't already exists
+	if mockConsul != nil {
+		mockConsul.Reset()
+	} else {
+		key := client.configBasePath
+		if strings.LastIndex(key, "/") == len(key)-1 {
+			key = key[:len(key)-1]
+		}
+
+		_, err := client.consulClient.KV().Delete(key, nil)
+		if !assert.NoError(t, err) {
+			t.Fatal()
+		}
+	}
+}
+
+func getUniqueServiceName() string {
+	return serviceName + strconv.Itoa(time.Now().Nanosecond())
+}

--- a/internal/pkg/consul/mock_consul.go
+++ b/internal/pkg/consul/mock_consul.go
@@ -1,0 +1,223 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package consul
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"time"
+
+	consulapi "github.com/hashicorp/consul/api"
+)
+
+const verbose = false
+
+type MockConsul struct {
+	keyValueStore     map[string]*consulapi.KVPair
+	serviceStore      map[string]consulapi.AgentService
+	serviceCheckStore map[string]consulapi.AgentCheck
+}
+
+func NewMockConsul() *MockConsul {
+	mock := MockConsul{}
+	mock.keyValueStore = make(map[string]*consulapi.KVPair)
+	mock.serviceStore = make(map[string]consulapi.AgentService)
+	mock.serviceCheckStore = make(map[string]consulapi.AgentCheck)
+	return &mock
+}
+
+var keyChannels map[string]chan bool
+var PrefixChannels map[string]chan bool
+
+func (mock *MockConsul) Reset() {
+	mock.keyValueStore = make(map[string]*consulapi.KVPair)
+	mock.serviceStore = make(map[string]consulapi.AgentService)
+	mock.serviceCheckStore = make(map[string]consulapi.AgentCheck)
+}
+
+func (mock *MockConsul) Start() *httptest.Server {
+	keyChannels = make(map[string]chan bool)
+	var consulIndex = 1
+	PrefixChannels = make(map[string]chan bool)
+
+	testMockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if strings.Contains(request.URL.Path, "/v1/kv/") {
+			key := strings.Replace(request.URL.Path, "/v1/kv/", "", 1)
+
+			switch request.Method {
+			case "PUT":
+				body := make([]byte, request.ContentLength)
+				if _, err := io.ReadFull(request.Body, body); err != nil {
+					log.Printf("error reading request body: %s", err.Error())
+				}
+
+				keyValuePair, found := mock.keyValueStore[key]
+				if found {
+					keyValuePair.ModifyIndex++
+					keyValuePair.Value = body
+				} else {
+					keyValuePair = &consulapi.KVPair{
+						Key:         key,
+						Value:       body,
+						ModifyIndex: 1,
+						CreateIndex: 1,
+						Flags:       0,
+						LockIndex:   0,
+					}
+				}
+
+				mock.keyValueStore[key] = keyValuePair
+
+				if verbose {
+					log.Printf("PUTing new value for %s", key)
+				}
+
+				channel, found := keyChannels[key]
+				if found {
+					channel <- true
+				}
+				for prefix, channel := range PrefixChannels {
+					if strings.HasPrefix(key, prefix) {
+						consulIndex++
+						if channel != nil {
+							channel <- true
+						}
+					}
+				}
+			case "GET":
+				// this is what the wait query parameters will look like "index=1&wait=600000ms"
+				var pairs consulapi.KVPairs
+				var prefixFound bool
+				query := request.URL.Query()
+				waitTime := query.Get("wait")
+				// Recurse parameters are usually set when prefix is monitored,
+				// if found we need to find all keys with prefix set in URL.
+				_, recurseFound := query["recurse"]
+				_, allKeysRequested := query["keys"]
+				if recurseFound {
+					pairs, prefixFound = mock.checkForPrefix(key)
+					if !prefixFound {
+						http.NotFound(writer, request)
+						return
+					}
+					//Default wait time is 30 minutes, over riding it for unit test purpose
+					waitTime = "1s"
+					if waitTime != "" {
+						waitForNextPutPrefix(key, waitTime)
+					}
+					writer.Header().Set("X-Consul-Index", strconv.Itoa(consulIndex))
+				} else if allKeysRequested {
+					// Just returning array of key names
+					var keys []string
+
+					pairs, prefixFound = mock.checkForPrefix(key)
+					if !prefixFound {
+						http.NotFound(writer, request)
+						return
+					}
+
+					for _, key := range pairs {
+						keys = append(keys, key.Key)
+					}
+
+					jsonData, _ := json.MarshalIndent(&keys, "", "  ")
+
+					writer.Header().Set("Content-Type", "application/json")
+					writer.WriteHeader(http.StatusOK)
+					if _, err := writer.Write(jsonData); err != nil {
+						log.Printf("error writing data response: %s", err.Error())
+					}
+
+				} else {
+					keyValuePair, found := mock.keyValueStore[key]
+					pairs = consulapi.KVPairs{keyValuePair}
+					if !found {
+						http.NotFound(writer, request)
+						return
+					}
+				}
+
+				jsonData, _ := json.MarshalIndent(&pairs, "", "  ")
+
+				writer.Header().Set("Content-Type", "application/json")
+				writer.WriteHeader(http.StatusOK)
+				if _, err := writer.Write(jsonData); err != nil {
+					log.Printf("error writing data response: %s", err.Error())
+				}
+			}
+		} else if strings.Contains(request.URL.Path, "/v1/status/leader") {
+			switch request.Method {
+			case "GET":
+				writer.Header().Set("Content-Type", "application/json")
+				writer.WriteHeader(http.StatusOK)
+
+			}
+		}
+	}))
+
+	return testMockServer
+}
+
+func waitForNextPutPrefix(key string, waitTime string) {
+	timeout, err := time.ParseDuration(waitTime)
+	if err != nil {
+		log.Printf("Error parsing waitTime %s into a duration: %s", waitTime, err.Error())
+	}
+	channel := make(chan bool)
+	PrefixChannels[key] = channel
+	timedOut := false
+	go func() {
+		time.Sleep(timeout)
+		timedOut = true
+		if PrefixChannels[key] != nil {
+			PrefixChannels[key] <- true
+			if verbose {
+				log.Printf("Timed out watching for change on %s", key)
+			}
+		}
+	}()
+
+	if verbose {
+		log.Printf("Watching for change on %s", key)
+	}
+
+	<-channel
+	close(channel)
+	PrefixChannels[key] = nil
+	if !timedOut {
+		log.Printf("%s changed", key)
+	}
+}
+
+func (mock *MockConsul) checkForPrefix(prefix string) (consulapi.KVPairs, bool) {
+	var pairs consulapi.KVPairs
+	for k, v := range mock.keyValueStore {
+		if strings.HasPrefix(k, prefix) {
+			pairs = append(pairs, v)
+		}
+	}
+	if len(pairs) == 0 {
+		return nil, false
+	}
+	return pairs, true
+
+}

--- a/pkg/types/service_config.go
+++ b/pkg/types/service_config.go
@@ -1,0 +1,79 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package types
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// ServiceConfig defines the information need to connect to the Configuration service and optionally register the service
+// for discovery and health checks
+type ServiceConfig struct {
+	// The Protocol that should be used to connect to the Configuration service. HTTP is used if not set.
+	Protocol string
+	// Host is the hostname or IP address of the Configuration service
+	Host string
+	// Port is the HTTP port of the Configuration service
+	Port int
+	// Type is the implementation type of the Configuration service, i.e. consul
+	Type string
+	// BasePath is the base path with in the Configuration service where the your service's configuration is stored
+	BasePath string
+}
+
+//
+// A few helper functions for building URLs.
+//
+
+func (config ServiceConfig) GetUrl() string {
+	return fmt.Sprintf("%s://%s:%v", config.GetProtocol(), config.Host, config.Port)
+}
+
+func (config *ServiceConfig) GetProtocol() string {
+	if config.Protocol == "" {
+		return "http"
+	}
+
+	return config.Protocol
+}
+
+func (config *ServiceConfig) PopulateFromUrl(providerUrl string) error {
+	url, err := url.Parse(providerUrl)
+	if err != nil {
+		return fmt.Errorf("the format of Configuration Provider path from argument is wrong: %s", err.Error())
+	}
+
+	port, err := strconv.Atoi(url.Port())
+	if err != nil {
+		return fmt.Errorf("the port format of Configuration Provider path from argument is wrong: %s", err.Error())
+	}
+
+	typeAndProtocol := strings.Split(url.Scheme, ".")
+	if len(typeAndProtocol) != 2 {
+		return fmt.Errorf("the Type and Protocol spec of Configuration Provider path from argument is wrong: %s", err.Error())
+	}
+
+	config.Protocol = typeAndProtocol[1]
+	config.Host = url.Hostname()
+	config.Port = port
+	config.Type = typeAndProtocol[0]
+
+	return nil
+}


### PR DESCRIPTION
Code was extracted from the abstract Registry implementation in go-mod-registry. Then applied these changes:
- Name refactoring to change from `Registry` to `Configuration`
- Removed any Service Registry specific code/variables/unit tests/mocks
- Addressed https://github.com/edgexfoundry/go-mod-registry/issues/14

closes #2 